### PR TITLE
lowering keysize for due to bug in jdk on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ You may also find these slides interesting: [Bring your infrastructure under con
 
 ### Examples
 A catalog of examples grows [here](https://github.com/infrastructor/examples) 
+
+

--- a/infrastructor-core/src/main/java/io/infrastructor/core/utils/CryptoUtils.groovy
+++ b/infrastructor-core/src/main/java/io/infrastructor/core/utils/CryptoUtils.groovy
@@ -21,7 +21,7 @@ class CryptoUtils {
     def static final OUTPUT_BLOCK_SIZE = 80
 
     private static SecretKeySpec prepareKey(byte[] key) {
-        return new SecretKeySpec(Arrays.copyOf(key, 32), "AES")
+        return new SecretKeySpec(Arrays.copyOf(key, 16), "AES")
     }
 
     private static GCMParameterSpec prepareParams(byte[] iv) {


### PR DESCRIPTION
Due to a jdk bug there is an issue with keysize length bigger than 16 in high sierra. Please consider to use this setting as it will add compatibility for both mac and common linux systems. 